### PR TITLE
EOF marker mismatch due to trailing space

### DIFF
--- a/util/crontabAdd.sh
+++ b/util/crontabAdd.sh
@@ -5,7 +5,7 @@ export BARCHART_HOME && ${BARCHART_HOME}/util/crontabRemove.sh
 # use , as sed delimiter
 sed "s,@@HOMEDIR@@,${BARCHART_HOME}," "${BARCHART_HOME}/util/crontab.txt" > "${BARCHART_HOME}/TEMPcrontab.txt"
 # remove BirdWeather if there is no token
-if [ ! -n "$BIRDWEATHER_ID" ]; then
+if [ -z "$BIRDWEATHER_ID" ]; then
     sed -i '/BirdWeather/d' "${BARCHART_HOME}/TEMPcrontab.txt"
 fi
 # set the crontab using TEMPcrontab.txt

--- a/util/update-2.3-tasks.sh
+++ b/util/update-2.3-tasks.sh
@@ -29,16 +29,13 @@ else
 	echo "add database indexes"
 # -----
 sqlite3 ${BARCHART_HOME}/birds.db << EOF
--- -----
 CREATE INDEX heardCommonName ON heard (
 	commonName
 	);
--- -----
 CREATE INDEX heardMinuteOfDay ON heard (
 	minuteOfDay
 	);
--- -----
-EOF	
+EOF
 # -----
 fi
 # how long did it take


### PR DESCRIPTION
Also used -z rather than ! -n for empty variable check.